### PR TITLE
Modules support for >= v9

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/ip2location/ip2location-go/v9
+
+go 1.14


### PR DESCRIPTION
Adds Go module support starting at v9. Will require a `v9.0.0` tag after merge.