### PR TITLE
Remove usage of unsafe

### DIFF
--- a/ip2location.go
+++ b/ip2location.go
@@ -10,13 +10,13 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"lukechampine.com/uint128"
 	"math"
 	"math/big"
 	"net"
 	"os"
 	"strconv"
-	"unsafe"
+
+	"lukechampine.com/uint128"
 )
 
 type DBReader interface {
@@ -628,11 +628,9 @@ func handleError(rec IP2Locationrecord, err error) IP2Locationrecord {
 	return rec
 }
 
-// convertBytesToString provides a no-copy []byte to string conversion.
-// This implementation is adopted by official strings.Builder.
-// Reference: https://github.com/golang/go/issues/25484
+// convertBytesToString converts a byte slice to string efficiently
 func convertBytesToString(b []byte) string {
-	return *(*string)(unsafe.Pointer(&b))
+	return string(b)
 }
 
 // Get_all will return all geolocation fields based on the queried IP address.


### PR DESCRIPTION
Packages that export or use "unsafe" and/or "syscall" cannot be used in the Yaegi plugin interpreter.

https://github.com/traefik/yaegi

This is used by Traefik to support it's plugin system.

https://github.com/traefik/traefik

This PR removes an optimization in the existing implementation where unsafe is used.